### PR TITLE
feat: add variables related to the DynamoDB billing mode for the state_lock module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ data "aws_caller_identity" "provider" {}
 
 module "state_lock" {
   source  = "cloudposse/dynamodb/aws"
-  version = "0.29.5"
+  version = "0.30.0"
 
   enabled           = var.lock
   attributes        = local.dynamo_attributes
@@ -28,6 +28,10 @@ module "state_lock" {
   enable_autoscaler = local.dynamo_enable_autoscaler
 
   context = module.this.context
+
+  billing_mode                 = var.dynamo_billing_mode
+  autoscale_min_read_capacity  = var.dynamo_min_read_capacity
+  autoscale_min_write_capacity = var.dynamo_min_write_capacity
 }
 
 data "aws_iam_policy_document" "state_policy_root" {

--- a/variables.tf
+++ b/variables.tf
@@ -43,3 +43,19 @@ variable "state_kms_policies" {
   default     = []
   description = "Additional policies attached to kms as list of aws_iam_policy_document "
 }
+
+variable "dynamo_billing_mode" {
+  type        = string
+  default     = "PAY_PER_REQUEST"
+  description = "DynamoDB Billing mode. Can be PROVISIONED or PAY_PER_REQUEST"
+}
+
+variable "dynamo_min_read_capacity" {
+  type        = number
+  description = "DynamoDB autoscaling min read capacity"
+}
+
+variable "dynamo_min_write_capacity" {
+  type        = number
+  description = "DynamoDB autoscaling min write capacity"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -52,10 +52,12 @@ variable "dynamo_billing_mode" {
 
 variable "dynamo_min_read_capacity" {
   type        = number
+  default     = null
   description = "DynamoDB autoscaling min read capacity"
 }
 
 variable "dynamo_min_write_capacity" {
   type        = number
+  default     = null
   description = "DynamoDB autoscaling min write capacity"
 }


### PR DESCRIPTION
# Description

- Add variables to the state_lock module and change the default value for dynamoDB billing_mode from `PROVISIONED` to `PAY_PER_REQUEST`
- bump version of `cloudposse/dynamodb/aws` module to `0.30.0`

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

Changes was tested in `tf-org` repo by `terraform plan` command and modifications appeared in the output also:

    # module.state_sandbox.module.state_lock.aws_dynamodb_table.default[0] will be updated in-place
    ~ resource "aws_dynamodb_table" "default" {
        ~ billing_mode   = "PROVISIONED" -> "PAY_PER_REQUEST"
          id             = "ref-sandbox-terraform-state-lock"
          name           = "ref-sandbox-terraform-state-lock"
        + table_class    = "STANDARD"