### PR TITLE
fix inputs for state-bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -128,7 +128,7 @@ module "state_bucket" {
   versioning_enabled      = local.bucket_versioning_enabled
   sse_algorithm           = var.state_sse
   kms_master_key_arn      = local.bucket_kms_key
-  source_policy_documents = data.aws_iam_policy_document.state_bucket_policy.json
+  source_policy_documents = [data.aws_iam_policy_document.state_bucket_policy.json]
 
   context = module.this.context
 }

--- a/main.tf
+++ b/main.tf
@@ -123,12 +123,12 @@ module "state_bucket" {
   source  = "cloudposse/s3-bucket/aws"
   version = "2.0.1"
 
-  enabled            = var.state
-  attributes         = local.bucket_attributes
-  versioning_enabled = local.bucket_versioning_enabled
-  sse_algorithm      = var.state_sse
-  kms_master_key_arn = local.bucket_kms_key
-  policy             = data.aws_iam_policy_document.state_bucket_policy.json
+  enabled                 = var.state
+  attributes              = local.bucket_attributes
+  versioning_enabled      = local.bucket_versioning_enabled
+  sse_algorithm           = var.state_sse
+  kms_master_key_arn      = local.bucket_kms_key
+  source_policy_documents = data.aws_iam_policy_document.state_bucket_policy.json
 
   context = module.this.context
 }


### PR DESCRIPTION
# Description

change input `source_policy_documents` which has not been updated with the change of the module `0.49.0` -> `2.0.1`

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

tested with terraform plan
